### PR TITLE
Update Makefile and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
-WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+WORKDIR /go/src/github.com/awslabs/volume-modifier-for-k8s
 COPY go.* .
 ARG GOPROXY=direct
 RUN go mod download
@@ -10,5 +10,5 @@ ARG VERSION
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest.2 AS linux-amazon
-COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
-ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
+COPY --from=builder /go/src/github.com/awslabs/volume-modifier-for-k8s/bin/volume-modifier-for-k8s /bin/volume-modifier-for-k8s
+ENTRYPOINT ["/bin/volume-modifier-for-k8s"]

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ clean:
 .PHONY: check
 check: check-proto
 
-.PHONY: linux/$(ARCH) bin/aws-ebs-csi-driver
-linux/$(ARCH): bin/aws-ebs-csi-driver
-bin/aws-ebs-csi-driver: | bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -mod=mod -ldflags ${LDFLAGS} -o bin/aws-ebs-csi-driver ./cmd
+.PHONY: linux/$(ARCH) bin/volume-modifier-for-k8s
+linux/$(ARCH): bin/volume-modifier-for-k8s
+bin/volume-modifier-for-k8s: | bin
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -mod=mod -ldflags ${LDFLAGS} -o bin/volume-modifier-for-k8s ./cmd
 
 .PHONY: check-proto
 check-proto:


### PR DESCRIPTION
The Makefile and Dockerfile referred to the binary as 'aws-ebs-csi-driver', instead of 'volume-modifier-for-k8s'. This commit fixes that.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
