### PR TITLE
Process PVC that transitioned to Bound phase

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -364,7 +364,10 @@ func (c *modifyController) needsProcessing(old *v1.PersistentVolumeClaim, new *v
 			return true
 		}
 	}
-	return false
+
+	hasBeenBound := old.Status.Phase != new.Status.Phase && new.Status.Phase == v1.ClaimBound
+	// If the annotation was set at creation we might have skipped the PVC because it was not bound yet
+	return len(annotations) > 0 && hasBeenBound
 }
 
 func getObjectKeys(obj interface{}) (string, error) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently when the PVC is created with the volume modification annotations, it's skipped in the AddFunc because the PVC is not bound yet and then it's never processed again because the annotations are unchanged after the status update.
The code add a check so that we correctly process a PVC that contains the annotations and changed to the ClaimBound status.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
