### PR TITLE
volume-modifier sidecar elects the same leader as external-resizer sidecar

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -142,12 +142,14 @@ func main() {
 	if !*enableLeaderElection {
 		run(context.TODO())
 	} else {
-		lockName := "volume-modifier-for-k8s-" + util.SanitizeName(modifierName)
+		// Ensure volume-modifier-for-k8s and external-resizer sidecars always elect the same leader
+		// by putting them on the same lease that is identified by the lock name.
+		externalResizerLockName := "external-resizer-" + util.SanitizeName(driverName)
 		leKubeClient, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			klog.Fatal(err.Error())
 		}
-		le := leaderelection.NewLeaderElection(leKubeClient, lockName, run)
+		le := leaderelection.NewLeaderElection(leKubeClient, externalResizerLockName, run)
 		if *httpEndpoint != "" {
 			le.PrepareHealthCheck(mux, leaderelection.DefaultHealthCheckTimeout)
 		}


### PR DESCRIPTION
***Description of changes:***
This PR ensures that `volume-modifier-for-k8s` sidecar elects the same leader as `external-resizer` sidecar by putting this sidecar on the same lease of the resizer sidecar for leader election. That lease is identified by the lock name `"external-resizer-" + util.SanitizeName(driverName)` , for example, `external-resizer-ebs-csi-aws-com`.

This feature works together with the Request Coalescing feature in EBS CSI Driver: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1676 . They are needed to resolve the failure use case of editing capacity and volume property of a PVC at the same time. volume-modifier-for-k8s and external-resizer sidecars need to have the same leader so that the RPC requests from them will go to the same CSI controller pod.

***Testing***
1. Deployed EBS CSI Driver with multiple replicas, using volume-modifier sidecar image built with the changes in this PR.
2. Inspect the lease via `kubectl get lease` . Find out which csi controller pod is the leader for the resizer lease
```
kubectl get lease -n kube-system
NAME                                          HOLDER                                                             AGE
external-resizer-ebs-csi-aws-com              ebs-csi-controller-84c4dd9b99-mcpnh                                48d
```
3. Got logs of the leading csi controller pod on the volume-modifier  and csi-resizer containers. Confirmed that both acquired leaders with the same lease kube-system/external-resizer-ebs-csi-aws-com.
```
kubectl logs ebs-csi-controller-84c4dd9b99-mcpnh  -n kube-system -c csi-resizer
I0808 13:46:17.349226       1 main.go:141] CSI driver name: "ebs.csi.aws.com"
I0808 13:46:17.350055       1 common.go:111] Probing CSI driver for readiness
I0808 13:46:17.354255       1 leaderelection.go:245] attempting to acquire leader lease kube-system/external-resizer-ebs-csi-aws-com...
I0808 13:54:14.712424       1 leaderelection.go:255] successfully acquired lease kube-system/external-resizer-ebs-csi-aws-com
I0808 13:54:14.712576       1 leader_election.go:178] became leader, starting
I0808 13:54:14.712596       1 controller.go:255] Starting external resizer ebs.csi.aws.com

kubectl logs ebs-csi-controller-84c4dd9b99-mcpnh  -n kube-system -c volumemodifier
I0808 13:46:17.260834       1 common.go:111] Probing CSI driver for readiness
I0808 13:46:17.267804       1 main.go:102] CSI driver name: "ebs.csi.aws.com"
I0808 13:46:17.268299       1 leaderelection.go:245] attempting to acquire leader lease kube-system/external-resizer-ebs-csi-aws-com...
I0808 13:54:22.441471       1 leaderelection.go:255] successfully acquired lease kube-system/external-resizer-ebs-csi-aws-com
```
4. Performed volume modification use case (steps in this [doc](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/modify-volume.md) ). Verified that the csi-resizer and volume-modifier in the leading CSI controller pod handled the PVC changes.
5. Deleted the leading csi controller pod `ebs-csi-controller-84c4dd9b99-mcpnh`. Repeated step 2, 3 and 4, and verified that the two sidecar elected the same csi controller pod for their new leader.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
