### PR TITLE
[controller] Properly retry failures

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -57,6 +57,7 @@ func NewModifyController(
 		claims:                 pvcInformer.Informer().GetStore(),
 		eventRecorder:          eventRecorder,
 		modificationInProgress: make(map[string]struct{}),
+		retryFailures:          retryModificationFailures,
 	}
 
 	pvcInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `retryModificationFailures` parameter was never used when initializing the modify controller. As a result, modification failures were not retried until the PVC was re-processed (because the driver restarted or the PVC re-added to the cache)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
