### PR TITLE
Resync all PVCs on leader election

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -102,6 +102,13 @@ func (c *modifyController) Run(workers int, ctx context.Context) {
 		return
 	}
 
+	// On startup, queue all existing PVCs - this ensures that PVCs
+	// awaiting modification (or otherwise in an inconsistent state)
+	// are processed immediately instead of waiting on a resync
+	for _, claim := range c.claims.List() {
+		c.addPVC(claim)
+	}
+
 	for i := 0; i < workers; i++ {
 		go wait.Until(c.syncPVCs, 0, stopCh)
 	}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When we resume operation after re-winning leader election, manually and immediately queue all PVCs for resync so if any are in an inconsistent state that we fix that immediately (instead of waiting for the resync period).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
