### PR TITLE
Create ModifyController on demand in main.go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -77,7 +77,7 @@ func TestLeaseHandler_PodRegainsLeadership(t *testing.T) {
 	leaseChannel := make(chan *v1.Lease, 3)
 	defer close(leaseChannel)
 
-	go leaseHandler("test-pod", mockModifyController, leaseChannel)
+	go leaseHandler("test-pod", func() controller.ModifyController { return mockModifyController }, leaseChannel)
 
 	// Become the leader
 	leaseChannel <- newLease("external-resizer-ebs-csi-aws-com", "test-pod")
@@ -113,7 +113,7 @@ func TestLeaseHandler_RunCalledOnce(t *testing.T) {
 	leaseChannel := make(chan *v1.Lease, 3)
 	defer close(leaseChannel)
 
-	go leaseHandler("test-pod", mockModifyController, leaseChannel)
+	go leaseHandler("test-pod", func() controller.ModifyController { return mockModifyController }, leaseChannel)
 
 	for i := 0; i < 10; i++ {
 		leaseChannel <- newLease("external-resizer-ebs-csi-aws-com", "test-pod")
@@ -140,7 +140,7 @@ func newLease(name, holderIdentity string) *v1.Lease {
 
 func runLeaseHandlerAndSendLease(t *testing.T, podName string, mockModifyController *controller.MockModifyController, lease *v1.Lease) {
 	leaseChannel := make(chan *v1.Lease, 1)
-	go leaseHandler(podName, mockModifyController, leaseChannel)
+	go leaseHandler(podName, func() controller.ModifyController { return mockModifyController }, leaseChannel)
 	leaseChannel <- lease
 	close(leaseChannel)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -65,6 +65,7 @@ func NewModifyController(
 		UpdateFunc: ctrl.updatePVC,
 		DeleteFunc: ctrl.deletePVC,
 	}, resyncPeriod)
+	informerFactory.Start(wait.NeverStop)
 
 	return ctrl
 }
@@ -366,13 +367,13 @@ func (c *modifyController) needsProcessing(old *v1.PersistentVolumeClaim, new *v
 	}
 
 	annotations := make(map[string]struct{})
-	for key, _ := range new.Annotations {
+	for key := range new.Annotations {
 		if c.isValidAnnotation(key) {
 			annotations[key] = struct{}{}
 		}
 	}
 
-	for a, _ := range annotations {
+	for a := range annotations {
 		oldValue := old.Annotations[a]
 		newValue := new.Annotations[a]
 


### PR DESCRIPTION
**Issue #, if available:** N/A

In the current implementation, when the modify controller is restarted (if the leader switches away and then back to the same pod), the volume-modifier gets stuck indefinitely because the `claimQueue` has been shutdown: https://github.com/awslabs/volume-modifier-for-k8s/blob/bb5fb08845ca3166d310c3220d01118dac052db5/pkg/controller/controller.go#L92

This state is difficult to debug from the logs, and requires manual intervention (restart of the pod) to remedy.

**Description of changes:**

I experimented with methods of fixing this via restarting/recreating the claim queue, but that lead to further problems (race condition when shutting down and starting in quick succession, memory leak from constantly piling up claim queue when not leader, etc). Ultimately, I landed on the solution of recreating the `ModifyController` entirely when it is started.

To do this, `leaseHandler` was modified to accept a function that returns a new `ModifyController`. Additionally, I need to start creating a new informer factory for each instance, as attempting to add a hook to an already running informer is not allowed.

This also has the minor performance benefit that the `volume-modifier` sidecar does not sit in the background running the informer and claim queue when not the current leader.

**Testing:**
1. Deploy EBS CSI Driver with `controller.volumeModificationFeature.enabled` set to `true`, `sidecars.volumemodifier.image` set appropriately, and `controller.replicaCount` set to `1` (this issue occurs with multiple replicas but is much easier to forcefully reproduce with one)

2. Forcefully switch leader
```
$ kubectl patch --namespace kube-system lease external-resizer-ebs-csi-aws-com -p '{"spec":{"holderIdentity":"fake-pod"}}'
lease.coordination.k8s.io/external-resizer-ebs-csi-aws-com patched
```

3. Wait until pod takes back leader
```
$ kubectl get --namespace kube-system lease external-resizer-ebs-csi-aws-com
NAME                               HOLDER     AGE
external-resizer-ebs-csi-aws-com   fake-pod   23m

< ... approx 15 seconds later ... >

$ kubectl get --namespace kube-system lease external-resizer-ebs-csi-aws-com
NAME                               HOLDER                                AGE
external-resizer-ebs-csi-aws-com   ebs-csi-controller-59f49bd8bb-g4r8s   23m
```

4. Check in `volumemodifier` logs that the controller was stopped and then started
```
$ kubectl logs --namespace kube-system ebs-csi-controller-59f49bd8bb-g4r8s volumemodifier
...
I0508 21:49:12.822148       1 main.go:195] "leaseHandler: Starting ModifyController" podName="ebs-csi-controller-59f49bd8bb-g4r8s" currentLeader="ebs-csi-controller-59f49bd8bb-g4r8s"
I0508 21:49:12.822347       1 controller.go:94] "Starting external modifier" name="ebs.csi.aws.com"
I0508 21:51:38.108399       1 main.go:198] "leaseHandler: Stopping ModifyController" podName="ebs-csi-controller-59f49bd8bb-g4r8s" currentLeader="fake-pod"
I0508 21:51:38.108443       1 controller.go:102] "Shutting down external modifier" name="ebs.csi.aws.com"
I0508 21:52:12.023900       1 main.go:195] "leaseHandler: Starting ModifyController" podName="ebs-csi-controller-59f49bd8bb-g4r8s" currentLeader="ebs-csi-controller-59f49bd8bb-g4r8s"
I0508 21:52:12.024109       1 controller.go:94] "Starting external modifier" name="ebs.csi.aws.com"
```

5. Perform the [EBS CSI `volume-modifier-for-k8s` example](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/modify-volume.md#volume-modifier-for-k8s-1)

On the released version (v0.5.1) of the modifier, this will get stuck. On this PR, it will be able to modify the volume.
