### PR TITLE
Add makefile target and GH action to help automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make
+      - run: make test
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+ifneq (,$(filter new-version,$(MAKECMDGOALS)))
+  NEW_VERSION := $(word 2,$(MAKECMDGOALS))
+  $(eval $(NEW_VERSION):;@:)
+endif
+
 PROTO_FILE=modify.proto
 PROTO_GENERATED_FILES_PATH=pkg/rpc
 # Extract from BUILD_PLATFORMS/REV to mimic csi-release-tools behavior
@@ -39,6 +44,13 @@ check: check-proto
 linux/$(ARCH): bin/volume-modifier-for-k8s
 bin/volume-modifier-for-k8s: | bin
 	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -mod=mod -ldflags ${LDFLAGS} -o bin/volume-modifier-for-k8s ./cmd
+
+.PHONY: new-version
+new-version:
+	@[ "$(NEW_VERSION)" ] || (echo "Usage: make new-version <version>" && exit 1)
+	sed -i 's/^REV ?= .*/REV ?= "$(NEW_VERSION)"/' Makefile
+	go get -u ./...
+	go mod tidy
 
 .PHONY: check-proto
 check-proto:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Two changes to help automate our release:
- Add a new makefile target `make new-release` that bumps the version and automatically fetches latest go deps.
- Add a GH action to automatically publish a new release when a tag is published (incredibly, GH doesn't have an official action for this, so I used a random popular third party one)

Testing:
```
$ make new-version v1.2.3
sed -i 's/^REV ?= .*/REV ?= "v1.2.3"/' Makefile
go get -u ./...
go: upgraded go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 => v0.67.0
go: upgraded google.golang.org/genproto/googleapis/rpc v0.0.0-20260316180232-0b37fe3546d5 => v0.0.0-20260319201613-d00831a3d3e7
go: upgraded k8s.io/csi-translation-lib v0.35.2 => v0.35.3
go: upgraded k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 => v0.0.0-20260319190234-28399d86e0b5
go mod tidy

volume-modifier-for-k8s via go v1.26.0 $ git diff
diff --git a/Makefile b/Makefile
index 0ac28ca..4443e5b 100644
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PROTO_GENERATED_FILES_PATH=pkg/rpc
 # Extract from BUILD_PLATFORMS/REV to mimic csi-release-tools behavior
 OS ?= $(word 1,$(BUILD_PLATFORMS))
 ARCH ?= $(word 2,$(BUILD_PLATFORMS))
-REV ?= "v0.9.4"
+REV ?= "v1.2.3"
 LDFLAGS="-X 'main.version=$(REV)'"
 .PHONY: all
 all: bin/volume-modifier-for-k8s
diff --git a/go.mod b/go.mod
index 90e47c4..132347f 100644
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
        k8s.io/api v0.35.3
        k8s.io/apimachinery v0.35.3
        k8s.io/client-go v0.35.3
-       k8s.io/csi-translation-lib v0.35.2
+       k8s.io/csi-translation-lib v0.35.3
        k8s.io/klog/v2 v2.140.0
        k8s.io/kubectl v0.35.3
 )
... rest of the diff cut for brevity, more changes to go.mod and go.sum ...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
