### PR TITLE
Revise deprecation date in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION]
 > This project has been deprecated in favor of the native Kubernetes [VolumeAttributesClass](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) API.
-> No new features will be added. Security and bug fixes will still be released until **April 1st, 2026**. See the [[Deprecation Announcement] volume-modifier-for-k8s](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2435) for more information.
+> No new features will be added. Security and bug fixes will still be released until **January 31st, 2027**. See the [[Deprecation Announcement] volume-modifier-for-k8s](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2435) for more information.
 
 `volume-modifier-for-k8s` is a sidecar deployed alongside CSI drivers to enable volume modification through annotations on the PVC.
 


### PR DESCRIPTION
Updated deprecation date for volume-modifier-for-k8s.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
